### PR TITLE
Fix declaration files generation

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,8 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "outDir": "dist",
-    "rootDir": "."
+    "rootDir": ".",
+    "declaration": true
   },
   "include": ["./src/**/*.ts", "./scripts/**/*.ts", "./assets/**/*.ts", "./src/run.js"]
 }


### PR DESCRIPTION
Typing files were not generated so it was not possible to use the library properly.