### PR TITLE
fix: luxon-related high risk security (2.4.0→2.5.2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@villedemontreal/scripting",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@villedemontreal/scripting",
-      "version": "2.1.6",
+      "version": "2.1.7",
       "license": "MIT",
       "dependencies": {
         "@caporal/core": "2.0.2",
         "@types/fs-extra": "9.0.13",
         "@types/lodash": "4.14.184",
-        "@villedemontreal/general-utils": "5.16.7",
+        "@villedemontreal/general-utils": "5.16.8",
         "fs-extra": "10.1.0",
         "is-class": "0.0.9",
         "java-properties": "1.0.2",
@@ -674,13 +674,14 @@
       "dev": true
     },
     "node_modules/@types/lodash": {
-      "version": "4.14.182",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.182.tgz",
-      "integrity": "sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q=="
+      "version": "4.14.184",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.184.tgz",
+      "integrity": "sha512-RoZphVtHbxPZizt4IcILciSWiC6dcn+eZ8oX9IWEYfDMcocdd42f7NPI6fQj+6zI8y4E0L7gu2pcZKLGTRaV9Q=="
     },
     "node_modules/@types/luxon": {
-      "version": "1.25.0",
-      "license": "MIT"
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-2.3.2.tgz",
+      "integrity": "sha512-WOehptuhKIXukSUUkRgGbj2c997Uv/iUgYgII8U7XLJqq9W2oF0kQ6frEznRQbdurioz+L/cdaIm4GutTQfgmA=="
     },
     "node_modules/@types/minimatch": {
       "version": "3.0.3",
@@ -706,8 +707,9 @@
       }
     },
     "node_modules/@types/rimraf": {
-      "version": "3.0.0",
-      "license": "MIT",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-F3OznnSLAUxFrCEu/L5PY8+ny8DtcFRjx7fZZ9bycvXRi3KPTRS9HOitGZwvPg0juRhXFWIeKX58cnX5YqLohQ==",
       "dependencies": {
         "@types/glob": "*",
         "@types/node": "*"
@@ -995,34 +997,27 @@
       "license": "ISC"
     },
     "node_modules/@villedemontreal/general-utils": {
-      "version": "5.16.7",
-      "resolved": "https://registry.npmjs.org/@villedemontreal/general-utils/-/general-utils-5.16.7.tgz",
-      "integrity": "sha512-Nbh5b1XU8P+mfpkn9o1vebVGgB7RiHcigwSUJblMNPxpXsQEVMHFGAd2sw3AnfMIBWByHcrnz6U7c1XmegAdLQ==",
+      "version": "5.16.8",
+      "resolved": "https://registry.npmjs.org/@villedemontreal/general-utils/-/general-utils-5.16.8.tgz",
+      "integrity": "sha512-U7rHvjEOpYh9DZgVsAhO6kNkGWOTZHKO/I52PDIiFsJjkjI4jFWOSYpPv9JjZOkWxbb1fA8xXKQhuxyO6K1jjg==",
       "dependencies": {
         "@types/app-root-path": "1.2.4",
-        "@types/lodash": "4.14.171",
-        "@types/luxon": "1.25.0",
-        "@types/rimraf": "3.0.0",
-        "app-root-path": "3.0.0",
+        "@types/lodash": "4.14.184",
+        "@types/luxon": "2.3.2",
+        "@types/rimraf": "3.0.2",
+        "app-root-path": "3.1.0",
         "get-port": "5.1.1",
-        "globby": "11.0.1",
-        "http-status-codes": "2.1.4",
+        "globby": "13.1.2",
+        "http-status-codes": "2.2.0",
         "lodash": "4.17.21",
-        "luxon": "2.4.0",
+        "luxon": "2.5.2",
         "moment": "2.29.4",
         "rimraf": "3.0.2",
         "tsconfig-extends": "1.0.1"
+      },
+      "engines": {
+        "node": ">=16"
       }
-    },
-    "node_modules/@villedemontreal/general-utils/node_modules/@types/lodash": {
-      "version": "4.14.171",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.171.tgz",
-      "integrity": "sha512-7eQ2xYLLI/LsicL2nejW9Wyko3lcpN6O/z0ZLHrEQsg280zIdCv1t/0m6UtBjUHokCGBQ3gYTbHzDkZ1xOBwwg=="
-    },
-    "node_modules/@villedemontreal/general-utils/node_modules/http-status-codes": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.1.4.tgz",
-      "integrity": "sha512-MZVIsLKGVOVE1KEnldppe6Ij+vmemMuApDfjhVSLzyYP+td0bREEYyAoIw9yFePoBXManCuBqmiNP5FqJS5Xkg=="
     },
     "node_modules/acorn": {
       "version": "8.7.1",
@@ -1121,8 +1116,9 @@
       }
     },
     "node_modules/app-root-path": {
-      "version": "3.0.0",
-      "license": "MIT",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-3.1.0.tgz",
+      "integrity": "sha512-biN3PwB2gUtjaYy/isrU3aNWI5w+fAfvHkSvCKeQGxhmYpwKFUxudR3Yya+KqVRHBmEDYh+/lTozYCFbmzX4nA==",
       "engines": {
         "node": ">= 6.0.0"
       }
@@ -1158,6 +1154,7 @@
     },
     "node_modules/array-union": {
       "version": "2.1.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2418,18 +2415,29 @@
       }
     },
     "node_modules/globby": {
-      "version": "11.0.1",
-      "license": "MIT",
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-13.1.2.tgz",
+      "integrity": "sha512-LKSDZXToac40u8Q1PQtZihbNdTYSNMuWe+K5l+oa6KgDzSvVrHXlJy40hUP522RjAIoNLJYBJi7ow+rbFpIhHQ==",
       "dependencies": {
-        "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
-        "fast-glob": "^3.1.1",
-        "ignore": "^5.1.4",
-        "merge2": "^1.3.0",
-        "slash": "^3.0.0"
+        "fast-glob": "^3.2.11",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^4.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globby/node_modules/slash": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+      "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+      "engines": {
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -2522,6 +2530,11 @@
       "version": "2.0.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/http-status-codes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.2.0.tgz",
+      "integrity": "sha512-feERVo9iWxvnejp3SEfm/+oNG517npqL2/PIA8ORjyOZjGC7TwCRQsZylciLS64i6pJ0wRYz3rkXLRwbtFa8Ng=="
     },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
@@ -3126,11 +3139,11 @@
       }
     },
     "node_modules/luxon": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-2.4.0.tgz",
-      "integrity": "sha512-w+NAwWOUL5hO0SgwOHsMBAmZ15SoknmQXhSO0hIbJCAmPKSsGeK8MlmhYh2w6Iib38IxN2M+/ooXWLbeis7GuA==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-2.5.2.tgz",
+      "integrity": "sha512-Yg7/RDp4nedqmLgyH0LwgGRvMEKVzKbUdkBYyCosbHgJ+kaOUx0qzSiSatVc3DFygnirTPYnMM2P5dg2uH1WvA==",
       "engines": {
-        "node": "*"
+        "node": ">=12"
       }
     },
     "node_modules/make-dir": {
@@ -3400,9 +3413,9 @@
       }
     },
     "node_modules/moment": {
-      "version": "2.29.2",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.2.tgz",
-      "integrity": "sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg==",
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
       "engines": {
         "node": "*"
       }
@@ -4301,6 +4314,7 @@
     },
     "node_modules/slash": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5473,12 +5487,14 @@
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.182",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.182.tgz",
-      "integrity": "sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q=="
+      "version": "4.14.184",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.184.tgz",
+      "integrity": "sha512-RoZphVtHbxPZizt4IcILciSWiC6dcn+eZ8oX9IWEYfDMcocdd42f7NPI6fQj+6zI8y4E0L7gu2pcZKLGTRaV9Q=="
     },
     "@types/luxon": {
-      "version": "1.25.0"
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-2.3.2.tgz",
+      "integrity": "sha512-WOehptuhKIXukSUUkRgGbj2c997Uv/iUgYgII8U7XLJqq9W2oF0kQ6frEznRQbdurioz+L/cdaIm4GutTQfgmA=="
     },
     "@types/minimatch": {
       "version": "3.0.3"
@@ -5502,7 +5518,9 @@
       }
     },
     "@types/rimraf": {
-      "version": "3.0.0",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-F3OznnSLAUxFrCEu/L5PY8+ny8DtcFRjx7fZZ9bycvXRi3KPTRS9HOitGZwvPg0juRhXFWIeKX58cnX5YqLohQ==",
       "requires": {
         "@types/glob": "*",
         "@types/node": "*"
@@ -5689,35 +5707,23 @@
       "dev": true
     },
     "@villedemontreal/general-utils": {
-      "version": "5.16.7",
-      "resolved": "https://registry.npmjs.org/@villedemontreal/general-utils/-/general-utils-5.16.7.tgz",
-      "integrity": "sha512-Nbh5b1XU8P+mfpkn9o1vebVGgB7RiHcigwSUJblMNPxpXsQEVMHFGAd2sw3AnfMIBWByHcrnz6U7c1XmegAdLQ==",
+      "version": "5.16.8",
+      "resolved": "https://registry.npmjs.org/@villedemontreal/general-utils/-/general-utils-5.16.8.tgz",
+      "integrity": "sha512-U7rHvjEOpYh9DZgVsAhO6kNkGWOTZHKO/I52PDIiFsJjkjI4jFWOSYpPv9JjZOkWxbb1fA8xXKQhuxyO6K1jjg==",
       "requires": {
         "@types/app-root-path": "1.2.4",
-        "@types/lodash": "4.14.171",
-        "@types/luxon": "1.25.0",
-        "@types/rimraf": "3.0.0",
-        "app-root-path": "3.0.0",
+        "@types/lodash": "4.14.184",
+        "@types/luxon": "2.3.2",
+        "@types/rimraf": "3.0.2",
+        "app-root-path": "3.1.0",
         "get-port": "5.1.1",
-        "globby": "11.0.1",
-        "http-status-codes": "2.1.4",
+        "globby": "13.1.2",
+        "http-status-codes": "2.2.0",
         "lodash": "4.17.21",
-        "luxon": "2.4.0",
+        "luxon": "2.5.2",
         "moment": "2.29.4",
         "rimraf": "3.0.2",
         "tsconfig-extends": "1.0.1"
-      },
-      "dependencies": {
-        "@types/lodash": {
-          "version": "4.14.171",
-          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.171.tgz",
-          "integrity": "sha512-7eQ2xYLLI/LsicL2nejW9Wyko3lcpN6O/z0ZLHrEQsg280zIdCv1t/0m6UtBjUHokCGBQ3gYTbHzDkZ1xOBwwg=="
-        },
-        "http-status-codes": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.1.4.tgz",
-          "integrity": "sha512-MZVIsLKGVOVE1KEnldppe6Ij+vmemMuApDfjhVSLzyYP+td0bREEYyAoIw9yFePoBXManCuBqmiNP5FqJS5Xkg=="
-        }
       }
     },
     "acorn": {
@@ -5779,7 +5785,9 @@
       }
     },
     "app-root-path": {
-      "version": "3.0.0"
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-3.1.0.tgz",
+      "integrity": "sha512-biN3PwB2gUtjaYy/isrU3aNWI5w+fAfvHkSvCKeQGxhmYpwKFUxudR3Yya+KqVRHBmEDYh+/lTozYCFbmzX4nA=="
     },
     "append-transform": {
       "version": "2.0.0",
@@ -5806,7 +5814,8 @@
       }
     },
     "array-union": {
-      "version": "2.1.0"
+      "version": "2.1.0",
+      "dev": true
     },
     "asap": {
       "version": "2.0.6",
@@ -6651,14 +6660,22 @@
       "dev": true
     },
     "globby": {
-      "version": "11.0.1",
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-13.1.2.tgz",
+      "integrity": "sha512-LKSDZXToac40u8Q1PQtZihbNdTYSNMuWe+K5l+oa6KgDzSvVrHXlJy40hUP522RjAIoNLJYBJi7ow+rbFpIhHQ==",
       "requires": {
-        "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
-        "fast-glob": "^3.1.1",
-        "ignore": "^5.1.4",
-        "merge2": "^1.3.0",
-        "slash": "^3.0.0"
+        "fast-glob": "^3.2.11",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^4.0.0"
+      },
+      "dependencies": {
+        "slash": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+          "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew=="
+        }
       }
     },
     "graceful-fs": {
@@ -6711,6 +6728,11 @@
     "html-escaper": {
       "version": "2.0.2",
       "dev": true
+    },
+    "http-status-codes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.2.0.tgz",
+      "integrity": "sha512-feERVo9iWxvnejp3SEfm/+oNG517npqL2/PIA8ORjyOZjGC7TwCRQsZylciLS64i6pJ0wRYz3rkXLRwbtFa8Ng=="
     },
     "iconv-lite": {
       "version": "0.4.24",
@@ -7115,9 +7137,9 @@
       }
     },
     "luxon": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-2.4.0.tgz",
-      "integrity": "sha512-w+NAwWOUL5hO0SgwOHsMBAmZ15SoknmQXhSO0hIbJCAmPKSsGeK8MlmhYh2w6Iib38IxN2M+/ooXWLbeis7GuA=="
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-2.5.2.tgz",
+      "integrity": "sha512-Yg7/RDp4nedqmLgyH0LwgGRvMEKVzKbUdkBYyCosbHgJ+kaOUx0qzSiSatVc3DFygnirTPYnMM2P5dg2uH1WvA=="
     },
     "make-dir": {
       "version": "3.1.0",
@@ -7303,9 +7325,9 @@
       }
     },
     "moment": {
-      "version": "2.29.2",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.2.tgz",
-      "integrity": "sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg=="
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
     },
     "ms": {
       "version": "2.1.2"
@@ -7878,7 +7900,8 @@
       "requires": {}
     },
     "slash": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "dev": true
     },
     "slice-ansi": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@villedemontreal/scripting",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "description": "Scripting core utilities",
   "main": "dist/src/index.js",
   "typings": "dist/src",
@@ -37,7 +37,7 @@
     "@caporal/core": "2.0.2",
     "@types/fs-extra": "9.0.13",
     "@types/lodash": "4.14.184",
-    "@villedemontreal/general-utils": "5.16.7",
+    "@villedemontreal/general-utils": "5.16.8",
     "fs-extra": "10.1.0",
     "is-class": "0.0.9",
     "java-properties": "1.0.2",


### PR DESCRIPTION
More info: [GHSA-3xq5-wjfh-ppjc](https://github.com/moment/luxon/security/advisories/GHSA-3xq5-wjfh-ppjc)

This pr do not pollute lock file with registry other than npm